### PR TITLE
Upgraded logic to work with React v0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-batched-updates",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Batch React updates that occur as a result of Redux dispatches.",
   "main": "lib/index.js",
   "scripts": {
@@ -28,7 +28,9 @@
     "jsdom": "^5.6.0",
     "mocha": "^2.2.5",
     "mocha-jsdom": "^1.0.0",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
+    "react-dom": "^0.14.0",
     "redux": "^0.12.0",
     "sinon": "^1.15.4"
   }

--- a/src/__tests__/jsdom.js
+++ b/src/__tests__/jsdom.js
@@ -1,7 +1,5 @@
-import ExecutionEnvironment from 'react/lib/ExecutionEnvironment';
 import jsdom from 'mocha-jsdom';
 
 export default function jsdomReact() {
   jsdom();
-  ExecutionEnvironment.canUseDOM = true;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
-import { addons } from 'react/addons';
+/*eslint camelcase: 0*/
+import { unstable_batchedUpdates as reactBatchedUpdates } from 'react-dom';
 
 export function batchedUpdatesMiddleware() {
-  return next => action => addons.batchedUpdates(() => next(action));
+  return next => action => reactBatchedUpdates(() => next(action));
 }
 
 export function batchedUpdates(next) {


### PR DESCRIPTION
Upgraded to work with React v0.14
## Changes
- Upgraded react dependency
- Added `react-dom` dependency
- Now uses `unstable_batchedUpdates` rather than the `batchedUpdates`-addon

_Tests_:
- Uses the `renderSpy` to pass results back to the test. React does not like that we access the props of the rendered `div`
